### PR TITLE
Refactor #13 다크모드 UI수정

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/app/Main View.swift
+++ b/app/Main View.swift
@@ -83,7 +83,7 @@ struct ContentView: View {
                                 if let name = wishItem.busStopName {
                                     if let nextName = wishItem.nextBusStop {
                                         NavigationLink(destination: busInfoResult(busStopName: name, busStopID: Int(wishItem.busStopID), nextBusStop: nextName)) {
-                                            Text(name)
+                                            Text(name + " (" + nextName + " 방향)")
                                         }
                                     } else {
                                         Text("Unknown")

--- a/app/searchResultView.swift
+++ b/app/searchResultView.swift
@@ -21,14 +21,12 @@ struct busInfoResult: View {
                 Section(header: HStack {
                     Text(busStopName)
                         .font(.custom("NotoSans-Bold", size: 24))
-                        .foregroundColor(.black)
                         .lineLimit(1) // 한 줄로 제한
                         .minimumScaleFactor(0.5) // 최소 축소 비율 설정
                         .padding(.leading, 20) // 왼쪽 여백 추가
                     Spacer()
                     Text(nextBusStop + " 방향")
                         .font(.subheadline)
-                        .foregroundColor(.black)
                         .lineLimit(1) // 한 줄로 제한
                         .minimumScaleFactor(0.5) // 최소 축소 비율 설정
                         .padding(.trailing, 38) // 오른쪽 여백 추가


### PR DESCRIPTION
issue #13

- foregroundColor(.black)을 해제해서 다크모드에서 검정색으로 보이는 이슈
- 해당 행 삭제로 자동적으로 SwiftUI에서 다크모드에 대응 할 수 있도록 해결